### PR TITLE
Added fallback build type

### DIFF
--- a/examples/mix-c-asm/430/CMakeLists.txt
+++ b/examples/mix-c-asm/430/CMakeLists.txt
@@ -6,7 +6,12 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
-  
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/mix-c-asm/8051/CMakeLists.txt
+++ b/examples/mix-c-asm/8051/CMakeLists.txt
@@ -6,7 +6,12 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
-  
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/mix-c-asm/arm/CMakeLists.txt
+++ b/examples/mix-c-asm/arm/CMakeLists.txt
@@ -7,6 +7,11 @@ project(Example1
   VERSION 1.0.0
   LANGUAGES C ASM )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/mix-c-asm/avr/CMakeLists.txt
+++ b/examples/mix-c-asm/avr/CMakeLists.txt
@@ -6,6 +6,11 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
   
 # Add the executable for the "mixLanguages" target,
 # specifying its source files

--- a/examples/mix-c-asm/rh850/CMakeLists.txt
+++ b/examples/mix-c-asm/rh850/CMakeLists.txt
@@ -6,7 +6,12 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
-  
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/mix-c-asm/riscv/CMakeLists.txt
+++ b/examples/mix-c-asm/riscv/CMakeLists.txt
@@ -7,6 +7,11 @@ project(Example1
   VERSION 1.0.0
   LANGUAGES C ASM )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Set multiple configuration types for multi-config generators
 set(CMAKE_CONFIGURATION_TYPES "Debug;RelWithDebInfo;Release;MinSizeRel")
   

--- a/examples/mix-c-asm/rl78/CMakeLists.txt
+++ b/examples/mix-c-asm/rl78/CMakeLists.txt
@@ -6,7 +6,12 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
-  
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/mix-c-asm/rx/CMakeLists.txt
+++ b/examples/mix-c-asm/rx/CMakeLists.txt
@@ -6,7 +6,12 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
-  
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/mix-c-asm/stm8/CMakeLists.txt
+++ b/examples/mix-c-asm/stm8/CMakeLists.txt
@@ -6,7 +6,12 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
-  
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/mix-c-asm/v850/CMakeLists.txt
+++ b/examples/mix-c-asm/v850/CMakeLists.txt
@@ -6,7 +6,12 @@ project(Example1
   DESCRIPTION "Mixing C and Assembly"
   VERSION 1.0.0
   LANGUAGES C ASM )
-  
+
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Add the executable for the "mixLanguages" target,
 # specifying its source files
 add_executable(mixLanguages

--- a/examples/using-libs/430/CMakeLists.txt
+++ b/examples/using-libs/430/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/8051/CMakeLists.txt
+++ b/examples/using-libs/8051/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/arm/CMakeLists.txt
+++ b/examples/using-libs/arm/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/avr/CMakeLists.txt
+++ b/examples/using-libs/avr/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/rh850/CMakeLists.txt
+++ b/examples/using-libs/rh850/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/riscv/CMakeLists.txt
+++ b/examples/using-libs/riscv/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/rl78/CMakeLists.txt
+++ b/examples/using-libs/rl78/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/rx/CMakeLists.txt
+++ b/examples/using-libs/rx/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/stm8/CMakeLists.txt
+++ b/examples/using-libs/stm8/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 

--- a/examples/using-libs/v850/CMakeLists.txt
+++ b/examples/using-libs/v850/CMakeLists.txt
@@ -5,6 +5,11 @@ project (Example2
   VERSION 1.0.0
   LANGUAGES C )
 
+# Fallback option for generators other than `Ninja Multi-Config`
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Enable CTest
 enable_testing()
 


### PR DESCRIPTION
- CMake's generators other than `"Ninja Multi-Config"` might not set `CMAKE_BUILD_TYPE` whereas some target flags depends on that to set the correct flags in the examples.
- This update adds __Debug__ as fallback option in case the build type was not set by the generator during the configuration step.
- Fix #12.