### PR TITLE
Fix support to other generators

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,20 @@
 cmake_minimum_required(VERSION 3.22)
 
 set(TOOLKIT_DIR $ENV{TOOLKIT_DIR})
-set(CMAKE_GENERATOR "Ninja Multi-Config")
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
 list(APPEND CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo MinSizeRel)
 
 project(IAR-test LANGUAGES C CXX ASM)
 
-set(LINKER_MAP --map $<CONFIG>/$<TARGET_PROPERTY:NAME>.map)
+if(CMAKE_GENERATOR MATCHES "Ninja Multi-Config")
+  set(LINKER_MAP --map $<CONFIG>/$<TARGET_PROPERTY:NAME>.map)
+else()
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+  endif()
+  set(LINKER_MAP --map ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:NAME>-${CMAKE_BUILD_TYPE}.map)
+endif()
 
 # arch-specific
 if(TARGET_ARCH STREQUAL arm)

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,8 +35,8 @@ Export the `$IAR_TOOL_ROOT` environment variable, pointing to the top-level loca
 ### IAR_LMS2_SERVER_IP (optional)
 Export the `IAR_LMS2_SERVER_IP` environment variable pointing to the license server, if the client's 1st-time license setup is required. Applies to the `-GL` and `-NW` products. (Default: not set)
 
-### CMAKE_MAKE_PROGRAM (optional)
-Export the `CMAKE_MAKE_PROGRAM` environment variable to specify which generator to use. (Default: `Ninja`)
+### CMAKE_GENERATOR (optional)
+Export the `CMAKE_GENERATOR` environment variable to specify which generator to use. (Default: `Ninja Multi-Config`)
 
 ### MSYSTEM
 This environment variable is automatically set by MSYS2, MINGW64 and MINGW32. Cygwin users must set it manually.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -54,7 +54,7 @@ function lms2-setup() {
 }
 
 function find_icc() {
-  if [ -z "$MSYSTEM" ]; then
+  if [ "$MSYSTEM" = "" ]; then
     export CC="${p}";
     export CXX="${p}";
   else
@@ -67,7 +67,7 @@ function find_icc() {
 }
 
 function find_ilink() {
-  if [ -z "$MSYSTEM" ]; then
+  if [ "$MSYSTEM" = "" ]; then
     export ASM=$(dirname ${p})/iasm${a};
   else
     export ASM=$(cygpath -m $(dirname ${p})/iasm${a}${EXT});
@@ -76,7 +76,7 @@ function find_ilink() {
 }
 
 function find_xlink() {
-  if [ ! -z "$MSYSTEM" ]; then
+  if [ "$MSYSTEM" = "" ]; then
     export ASM=$(cygpath -m $(dirname ${p})/a${a}${EXT});
   else
     export ASM=$(dirname ${p})/a${a};
@@ -84,12 +84,10 @@ function find_xlink() {
   echo "Using ASM_COMPILER: $ASM";
 }
 
-function cmake_configure() {
-  # Remove stale builds
-  rm -rf _build*;
+function cmake_set_gen() {
   # If no CMAKE_GENERATOR is set, defaults to `Ninja Multi-Config`
-  if [ -z "${CMAKE_GENERATOR}" ]; then
-    if [ -z "$MSYSTEM" ]; then
+  if [ "$CMAKE_GENERATOR" = "" ]; then
+    if [ "$MSYSTEM" = "" ]; then
       export CMAKE_MAKE_PROGRAM=$(which ninja);
     else
       export CMAKE_MAKE_PROGRAM=$(cygpath -m $(which ninja));
@@ -102,6 +100,11 @@ function cmake_configure() {
   else
     export CONFIGURATION_TYPES=(Debug Release RelWithDebInfo MinSizeRel)
   fi
+}
+
+function cmake_configure() {
+  # Remove stale builds
+  rm -rf _build*;
   if [ -z ${CONFIGURATION_TYPES} ]; then
     cmake -B_builds -DTARGET_ARCH=${a} -DTOOLKIT_DIR=${TOOLKIT_DIR};
   else
@@ -175,6 +178,8 @@ function cmake_build() {
 
   fi
 }
+
+cmake_set_gen;
 
 echo "----------- ilink tools";
 ILINK_TOOL=(arm riscv rh850 rl78 rx stm8);

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -23,6 +23,10 @@
 #   CygWin users: must manually export the variable to CYGWIN
 #   (e.g., export MSYSTEM=CYGWIN)
 #
+# CMAKE_GENERATOR
+#   Default: "Ninja Multi-Config"
+#   (e.g., export CMAKE_GENERATOR="MinGW Makefiles")
+#
 
 BUILD_CFGS=(Debug RelWithDebInfo Release MinSizeRel)
 
@@ -81,29 +85,38 @@ function find_xlink() {
 }
 
 function cmake_configure() {
-  rm -rf _builds;
-  # If no CMAKE_MAKE_PROGRAM is set, defaults to ninja
-  if [ -z "$CMAKE_MAKE_PROGRAM" ]; then
+  # Remove stale builds
+  rm -rf _build*;
+  # If no CMAKE_GENERATOR is set, defaults to `Ninja Multi-Config`
+  if [ -z "${CMAKE_GENERATOR}" ]; then
     if [ -z "$MSYSTEM" ]; then
       export CMAKE_MAKE_PROGRAM=$(which ninja);
     else
       export CMAKE_MAKE_PROGRAM=$(cygpath -m $(which ninja));
     fi
+    if [ ! -f $CMAKE_MAKE_PROGRAM ]; then
+      echo "FATAL ERROR: CMAKE_MAKE_PROGRAM not found ($CMAKE_MAKE_PROGRAM). No ninja executable found either.";
+      exit 1;
+    fi
+    export CMAKE_GENERATOR="Ninja Multi-Config";
+  else
+    export CONFIGURATION_TYPES=(Debug Release RelWithDebInfo MinSizeRel)
   fi
-  if [ ! -f $CMAKE_MAKE_PROGRAM ]; then
-    echo "FATAL ERROR: CMAKE_MAKE_PROGRAM not found ($CMAKE_MAKE_PROGRAM). No ninja executable found either.";
-    exit 1;
+  if [ -z ${CONFIGURATION_TYPES} ]; then
+    cmake -B_builds -DTARGET_ARCH=${a} -DTOOLKIT_DIR=${TOOLKIT_DIR};
+  else
+    for cfg in ${CONFIGURATION_TYPES[@]}; do
+      cmake -B_build-${cfg} -DCMAKE_BUILD_TYPE=${cfg} -DTARGET_ARCH=${a} -DTOOLKIT_DIR=${TOOLKIT_DIR}
+    done
   fi
-  cmake -B _builds -G "Ninja Multi-Config" \
-    -DTARGET_ARCH=${a} \
-    -DTOOLKIT_DIR=${TOOLKIT_DIR};
   if [ $? -ne 0 ]; then
-    echo "FAIL: CMake configuration phase.";
+    echo "FATAL ERROR: CMake configuration phase.";
     exit 1;
   fi
 }
 
 function check_output() {
+  if [ -z ${CONFIGURATION_TYPES} ]; then
     if [ -f _builds/${cfg}/test-c.${OUTPUT_FORMAT,,} ]; then
       echo "+${cfg}:C   ${OUTPUT_FORMAT} built successfully.";
     else
@@ -119,20 +132,49 @@ function check_output() {
     else
       echo "-${cfg}:ASM ${OUTPUT_FORMAT} not built.";
     fi
+  else
+    if [ -f _build-${cfg}/test-c.${OUTPUT_FORMAT,,} ]; then
+      echo "+${cfg}:C   ${OUTPUT_FORMAT} built successfully.";
+    else
+      echo "-${cfg}:C   ${OUTPUT_FORMAT} not built.";
+    fi
+    if [ -f _build-${cfg}/test-cxx.${OUTPUT_FORMAT,,} ]; then
+      echo "+${cfg}:CXX ${OUTPUT_FORMAT} built successfully.";
+    else
+      echo "-${cfg}:CXX ${OUTPUT_FORMAT} not built.";
+    fi
+    if [ -f _build-${cfg}/test-asm.${OUTPUT_FORMAT,,} ]; then
+      echo "+${cfg}:ASM ${OUTPUT_FORMAT} built successfully.";
+    else
+      echo "-${cfg}:ASM ${OUTPUT_FORMAT} not built.";
+    fi
+  fi
 }
 
 function cmake_build() {
-  for cfg in ${BUILD_CFGS[@]}; do
-    echo "===== Build configuration: [${cfg}]";
-    cmake --build _builds --config ${cfg} --verbose;
-    if [ $? -ne 0 ]; then
-      echo "FAIL: CMake building phase (${cfg}).";
-      exit 1;
-    fi
-    check_output;
-  done
-}
+  if [ -z ${CONFIGURATION_TYPES} ]; then
+    for cfg in ${BUILD_CFGS[@]}; do
+      echo "===== Build configuration: [${cfg}]";
+      cmake --build _builds --config ${cfg} --verbose;
+      if [ $? -ne 0 ]; then
+        echo "FAIL: CMake building phase (${cfg}).";
+        exit 1;
+      fi
+      check_output;
+    done
+  else
+    for cfg in ${CONFIGURATION_TYPES[@]}; do
+      echo "===== Build configuration: [${cfg}]";
+      cmake --build _build-${cfg} --verbose;
+      if [ $? -ne 0 ]; then
+        echo "FAIL: CMake building phase (${cfg}).";
+        exit 1;
+      fi
+      check_output;
+    done
 
+  fi
+}
 
 echo "----------- ilink tools";
 ILINK_TOOL=(arm riscv rh850 rl78 rx stm8);
@@ -167,3 +209,4 @@ for r in ${IAR_TOOL_ROOT[@]}; do
     done
   done
 done
+


### PR DESCRIPTION
### Highlights 
- Now it is possible to set `CMAKE_GENERATOR` directly from an environment variable to use alternative generators such as `Unix Makefiles` or `Ninja`. Defaults is `Ninja Multi-Config`.
