### PR TITLE
Fix: set CMake for cross-compiling

### DIFF
--- a/examples/iar-toolchain.cmake
+++ b/examples/iar-toolchain.cmake
@@ -8,6 +8,9 @@ set(TOOLKIT arm)
 # Get the toolchain target from the TOOLKIT
 get_filename_component(CMAKE_SYSTEM_PROCESSOR ${TOOLKIT} NAME)
 
+# Set CMake for cross-compiling
+set(CMAKE_SYSTEM_NAME Generic)
+
 # IAR C Compiler
 find_program(CMAKE_C_COMPILER
   NAMES icc${CMAKE_SYSTEM_PROCESSOR}


### PR DESCRIPTION
We set `CMAKE_SYSTEM_NAME` to `Generic` in order to prevent CMake from overwriting it with the host's system name (e.g., `amd64`) when cross-compiling with the IAR compiler.

This commit reverts changes performed on 16bed53 during cleanup.

Fix #20.