### PR TITLE
Fix: iar-cspy-arm.cmake

### DIFF
--- a/examples/arm/iar-cspy-arm.cmake
+++ b/examples/arm/iar-cspy-arm.cmake
@@ -5,7 +5,7 @@ function(iar_cspy_add_test TARGET TEST_NAME EXPECTED_OUTPUT)
   find_program(CSPY_BAT
     NAMES cspybat CSpyBat
     PATHS ${TOOLKIT_DIR}/../common
-    PATH_SUFFIXES bin )
+    PATH_SUFFIXES bin)
 
   # Check if C-SPY is being run from BX
   if(WIN32)

--- a/examples/arm/iar-cspy-arm.cmake
+++ b/examples/arm/iar-cspy-arm.cmake
@@ -5,8 +5,7 @@ function(iar_cspy_add_test TARGET TEST_NAME EXPECTED_OUTPUT)
   find_program(CSPY_BAT
     NAMES cspybat CSpyBat
     PATHS ${TOOLKIT_DIR}/../common
-    PATH_SUFFIXES bin
-    REQUIRED )
+    PATH_SUFFIXES bin )
 
   # Check if C-SPY is being run from BX
   if(WIN32)


### PR DESCRIPTION
- cspybat is not strictly required (BX). The function find_program() is failing.