### PR TITLE
Fix linker options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ target_sources(tutorial PRIVATE tutorial.c)
 target_compile_options(tutorial PRIVATE --cpu=cortex-m4)
 
 # linker options
-target_link_options(tutorial PRIVATE --semihosting)
+target_link_options(tutorial PRIVATE
+  --cpu=cortex-m4
+  --semihosting)
 ```
 
 ### Enabling the IAR Compiler

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ add_test(NAME tutorialTest
 set_tests_properties(tutorialTest PROPERTIES PASS_REGULAR_EXPRESSION "Hello world!")
 ```
 
-- Since `CMakeLists.txt` was modified, the build system needs to be reconfigured:
+- Since `CMakeLists.txt` was modified, the build system needs to be reconfigured. Rebuilding the project will automatically force reconfiguration, creating the `CTestTestfile.cmake` file:
 ```
 cmake --build .
 ```

--- a/examples/libs/CMakeLists.txt
+++ b/examples/libs/CMakeLists.txt
@@ -12,7 +12,11 @@ add_subdirectory()
 # TODO 5: Link the `lib` against `libs`
 target_link_libraries()
 
-target_link_options(libs PRIVATE --semihosting)
+target_compile_options(libs PRIVATE --cpu=cortex-m4)
+
+target_link_options(libs PRIVATE
+  --cpu=cortex-m4
+  --semihosting)
 
 enable_testing()
 

--- a/examples/libs/lib/CMakeLists.txt
+++ b/examples/libs/lib/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources()
 
 # TODO 3: Using the `PUBLIC` scope, expose the `lib` headers (inc) to other targets
 target_include_directories()
+
+target_compile_options(lib PRIVATE --cpu=cortex-m4)

--- a/examples/mix/CMakeLists.txt
+++ b/examples/mix/CMakeLists.txt
@@ -8,7 +8,11 @@ add_executable(mix)
 # TODO 2: Add `fun.s` source to the `mix` target
 target_sources(mix PRIVATE main.c)
 
-target_link_options(mix PRIVATE --semihosting)
+target_compile_options(mix PRIVATE --cpu=cortex-m4)
+
+target_link_options(mix PRIVATE
+  --cpu=cortex-m4
+  --semihosting)
 
 enable_testing()
 

--- a/examples/version/CMakeLists.txt
+++ b/examples/version/CMakeLists.txt
@@ -13,7 +13,11 @@ configure_file()
 # TODO 3: Add the Project Binary Directory to the target's include directories
 target_include_directories()
 
-target_link_options(version PRIVATE --semihosting)
+target_compile_options(version PRIVATE --cpu=cortex-m4)
+
+target_link_options(version PRIVATE 
+  --cpu=cortex-m4
+  --semihosting)
 
 enable_testing()
 

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -14,7 +14,9 @@ target_sources(tutorial PRIVATE tutorial.c)
 target_compile_options(tutorial PRIVATE --cpu=cortex-m4)
 
 # linker options
-target_link_options(tutorial PRIVATE --semihosting)
+target_link_options(tutorial PRIVATE
+  --cpu=cortex-m4
+  --semihosting)
 
 # TODO 1: Enable testing in CMake
 


### PR DESCRIPTION
The tutorial and examples were using `ilinkarm`'s default CPU (`Cortex-M3`) whereas the debugger was set for (`Cortex-M4`). While this doesn't pose a problem for simple examples, the lack of specification might become misleading down the road. This PR fixes such ambiguity.