### PR TITLE
ci: add SCA to the workflow example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
     name: Build tutorial
     runs-on: ubuntu-24.04
     container: ghcr.io/iarsystems/arm
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+      packages: read
     steps:
     - name: Checkout project
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       working-directory: tutorial
       run: |
         ichecks --all --output build/checks.manifest
-        icstat --checks build/checks.manifest --db build/cstat.db --sarif_dir build -- iccarm tutorial.c
+        icstat --checks build/checks.manifest --db build/cstat.db --sarif_dir build analyze -- iccarm tutorial.c
     
     - name: Upload SARIF
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,5 @@ jobs:
     - name: Upload SARIF
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: build/tutorial.c.sarif
+        sarif_file: tutorial/build/tutorial.c.sarif
         category: cstat-analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,23 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v4
+
     - name: CMake - Configure
       working-directory: tutorial
       run: cmake -GNinja -Bbuild
+
     - name: CMake - Build
       working-directory: tutorial
       run: cmake --build build --verbose
+
+    - name: IAR C-STAT Static Analysis
+      working-directory: tutorial
+      run: |
+        ichecks --all --output build/checks.manifest
+        icstat --checks build/checks.manifest --db build/cstat.db --sarif_dir build -- iccarm tutorial.c
+    
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: build/tutorial.c.sarif
+        category: cstat-analysis


### PR DESCRIPTION
- Add C-STAT SCA with SARIF support to the workflow and integrate with GitHub's CodeQL.