### PR TITLE
chore: Add RTL selection flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ add_executable(tutorial)
 target_sources(tutorial PRIVATE tutorial.c)
 
 # compiler options
-target_compile_options(tutorial PRIVATE --cpu=cortex-m4)
+target_compile_options(tutorial PRIVATE
+  --dlib_config full
+  --cpu=cortex-m4)
 
 # linker options
 target_link_options(tutorial PRIVATE

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -11,7 +11,9 @@ add_executable(tutorial)
 target_sources(tutorial PRIVATE tutorial.c)
 
 # compiler options
-target_compile_options(tutorial PRIVATE --cpu=cortex-m4)
+target_compile_options(tutorial PRIVATE
+  --dlib_config full
+  --cpu=cortex-m4)
 
 # linker options
 target_link_options(tutorial PRIVATE


### PR DESCRIPTION
The full C runtime library selection can be selected at compile-time with `--dlib_config full`.

The compiler default is `--dlib_config normal`.