### PR TITLE
example: custom build configurations

### DIFF
--- a/examples/custom/CMakeLists.txt
+++ b/examples/custom/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 4.1.2)
+
+# TODO 1: Include CMake modules to the project
+
+project(custom)
+
+# Add multiple executables
+add_executable(sqrt_test)
+add_executable(sqrtf_test)
+
+target_sources(sqrt_test PRIVATE
+  sqrt.c
+)
+
+target_sources(sqrtf_test PRIVATE
+  sqrtf.c
+)
+
+# Set multiple target properties at once
+set_target_properties(
+  sqrt_test
+  sqrtf_test
+  PROPERTIES
+    COMPILE_OPTIONS --cpu=cortex-m4
+    LINK_OPTIONS --semihosting
+)
+
+# Add simulated tests
+iar_cspysim(sqrt_test)
+iar_cspysim(sqrtf_test)

--- a/examples/custom/iar-cspysim.cmake
+++ b/examples/custom/iar-cspysim.cmake
@@ -1,0 +1,46 @@
+include_guard()
+
+enable_testing()
+
+# Facilitate adding C-SPY tests driven by CTest
+macro(iar_cspysim TARGET)
+  find_program(CSPYBAT
+    NAMES CSpyBat CSpyBat.exe
+    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
+    PATH_SUFFIXES common/bin
+    REQUIRED
+  )
+  cmake_path(GET CSPYBAT PARENT_PATH COMMON_DIR)
+
+  find_library(LIBPROC
+    NAMES libarmproc.so libarmPROC.so armproc.dll
+    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
+    PATH_SUFFIXES arm/bin
+    REQUIRED
+  )
+  find_library(LIBSIM
+    NAMES libarmsim2.so libarmSIM2.so armsim2.dll
+    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
+    PATH_SUFFIXES arm/bin
+    REQUIRED
+  )
+  find_library(LIBSUPPORT
+    NAMES libarmLibsupportUniversal.so armLibsupportUniversal.dll
+    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
+    PATH_SUFFIXES arm/bin
+    REQUIRED
+  )
+
+  add_test(
+    NAME ${TARGET}
+    COMMAND ${CSPYBAT} ${LIBPROC} ${LIBSIM}
+      --plugin=${LIBSUPPORT}
+      --debug_file=$<TARGET_FILE:${TARGET}>
+      --macro=${CMAKE_CURRENT_SOURCE_DIR}/systick.mac
+      --silent
+      --backend
+        --cpu=cortex-m4
+        --semihosting )
+  # More than zero ticks are expected for this test
+  set_property(TEST ${TARGET} PROPERTY PASS_REGULAR_EXPRESSION "ticks: ")
+endmacro()

--- a/examples/custom/iar-custom.cmake
+++ b/examples/custom/iar-custom.cmake
@@ -1,0 +1,17 @@
+include_guard()
+
+# Enable all CMake default build configurations
+list(APPEND CMAKE_CONFIGURATION_TYPES Debug)
+list(APPEND CMAKE_CONFIGURATION_TYPES Release)
+list(APPEND CMAKE_CONFIGURATION_TYPES RelWithDebInfo)
+list(APPEND CMAKE_CONFIGURATION_TYPES MinSizeRel)
+
+# Add IAR C/C++ Compiler custom configuration for High Speed
+list(APPEND CMAKE_CONFIGURATION_TYPES HighSpeed)
+set(CMAKE_C_FLAGS_HIGHSPEED " -Ohs" CACHE INTERNAL "")
+set(CMAKE_CXX_FLAGS_HIGHSPEED " -Ohs" CACHE INTERNAL "")
+
+# Add IAR C/C++ Compiler custom configuration for Maximum Speed
+list(APPEND CMAKE_CONFIGURATION_TYPES MaxSpeed)
+set(CMAKE_C_FLAGS_MAXSPEED " -Ohs --no_size_constraints" CACHE INTERNAL "")
+set(CMAKE_CXX_FLAGS_MAXSPEED " -Ohs --no_size_constraints" CACHE INTERNAL "")

--- a/examples/custom/sqrt.c
+++ b/examples/custom/sqrt.c
@@ -1,0 +1,39 @@
+/**************************************************
+ *
+ * Copyright (c) 2025 IAR Systems AB.
+ *
+ * See LICENSE for detailed license information.
+ *
+ **************************************************/
+
+#include <intrinsics.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define ITERATIONS 100000
+#define INTERRUPT  10000
+
+const float f_input = 2.0f;
+float f_result;
+uint32_t ticks = 0;
+
+void SysTick_Handler(void);
+void SysTick_Handler(void) {
+  ticks++;
+}
+
+void main()
+{
+  __enable_interrupt();
+
+  for (uint32_t i = 0; i < ITERATIONS; i++) 
+    f_result = sqrtf(f_input);
+
+  __disable_interrupt();
+
+  printf("ticks: %u\n", ticks);
+  printf("cycles: %u\n", ticks * INTERRUPT);
+  printf("cycles/sqrtf(): %f\n", (float)(ticks * INTERRUPT / ITERATIONS ));
+}
+

--- a/examples/custom/sqrtf.c
+++ b/examples/custom/sqrtf.c
@@ -1,0 +1,39 @@
+/**************************************************
+ *
+ * Copyright (c) 2025 IAR Systems AB.
+ *
+ * See LICENSE for detailed license information.
+ *
+ **************************************************/
+
+#include <intrinsics.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define ITERATIONS 100000
+#define INTERRUPT  10000
+
+const double d_input = 2.0;
+double d_result;
+uint32_t ticks = 0;
+
+void SysTick_Handler(void);
+void SysTick_Handler(void) {
+  ticks++;
+}
+
+void main()
+{
+  __enable_interrupt();
+
+  for (uint32_t i = 0; i < ITERATIONS; i++) 
+    d_result = sqrt(d_input);
+
+  __disable_interrupt();
+
+  printf("ticks: %u\n", ticks);
+  printf("cycles: %u\n", ticks * INTERRUPT);
+  printf("cycles/sqrtf(): %f\n", (float)(ticks * INTERRUPT / ITERATIONS ));
+}
+

--- a/examples/custom/systick.mac
+++ b/examples/custom/systick.mac
@@ -1,0 +1,17 @@
+/**************************************************
+ *
+ * Copyright (c) 2025 IAR Systems AB.
+ *
+ * See LICENSE for detailed license information.
+ *
+ **************************************************/
+
+__var _SysTick_Interrupt;
+
+execUserSetup() {
+  _SysTick_Interrupt = __orderInterrupt("SysTick", 0, 10000, 0, 0, 0, 100);
+}
+
+execUserExit() {
+  __cancelInterrupt( _SysTick_Interrupt );
+}


### PR DESCRIPTION
Adds an interactive example on how to create custom build configurations in CMake that make use of the IAR C/C++ Compiler optimization levels for higher speeds.