### PR TITLE
tutorial: Updated toolchain version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Before you begin, you will need to download and install the IAR product, CMake a
 
 ## Building a Basic CMake Project
 >[!NOTE]
->While this guide is based on the IAR Build Tools for Arm (CXARM) 9.70.1 on Linux, it should work with other supported IAR products with no or minimal changes.
+>While this guide is based on the IAR Build Tools for Arm (CXARM) 9.70.2 on Linux, it should work with other supported IAR products with no or minimal changes.
 
 The most basic CMake project is an executable built from a single source code file. For simple projects like this, a `CMakeLists.txt` file with about half dozen of commands is all that is required.
 
@@ -88,14 +88,15 @@ We are ready to build our first project! Run CMake to configure the project and 
 ```console
 $ echo "main(){}" | /opt/iar/cxarm/arm/bin/iccarm --output $(mktemp) -
 
-   IAR ANSI C/C++ Compiler V9.70.1.475/LNX for ARM
+   IAR ANSI C/C++ Compiler V9.70.2.500/LNX for ARM
    Copyright 1999-2025 IAR Systems AB.
-   LMS Cloud License (LMSC 1.5.0)
+   LMS Cloud License (LMSC 2.1.1)
  
  4 bytes of CODE memory
 
 Errors: none
 Warnings: none
+
 ```
 
 - From the terminal, navigate to the [tutorial](tutorial) directory and create a build directory:
@@ -128,8 +129,8 @@ enable_testing()
 add_test(NAME tutorialTest
          COMMAND /opt/iar/cxarm/common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iar/cxarm/arm/bin/libarmPROC.so
-         /opt/iar/cxarm/arm/bin/libarmSIM2.so
+         /opt/iar/cxarm/arm/bin/libarmproc.so
+         /opt/iar/cxarm/arm/bin/libarmsim2.so
          --plugin=/opt/iar/cxarm/arm/bin/libarmLibsupportUniversal.so
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:tutorial>

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -12,7 +12,7 @@ target_sources(tutorial PRIVATE tutorial.c)
 
 # compiler options
 target_compile_options(tutorial PRIVATE
-  --dlib_config full
+  --dlib_config=full
   --cpu=cortex-m4)
 
 # linker options

--- a/tutorial/bxarm.cmake
+++ b/tutorial/bxarm.cmake
@@ -1,4 +1,4 @@
-# Toolchain File for the IAR C/C++ Compiler
+# Toolchain File for the IAR C/C++ Compiler (BX)
 
 # Set CMake for cross-compiling
 set(CMAKE_SYSTEM_NAME Generic)

--- a/tutorial/ewarm.cmake
+++ b/tutorial/ewarm.cmake
@@ -1,13 +1,13 @@
-# Toolchain File for the IAR C/C++ Compiler
+# Toolchain File for the IAR C/C++ Compiler (EW)
 
 # Set CMake for cross-compiling
 set(CMAKE_SYSTEM_NAME Generic)
 
 # Set CMake to use the IAR C/C++ Compiler from the IAR Embedded Workbench for Arm
 # Update the paths if using any different supported target/version
-set(CMAKE_ASM_COMPILER "C:/iar/ewarm-9.60.4/arm/bin/iasmarm.exe")
-set(CMAKE_C_COMPILER   "C:/iar/ewarm-9.60.4/arm/bin/iccarm.exe")
-set(CMAKE_CXX_COMPILER "C:/iar/ewarm-9.60.4/arm/bin/iccarm.exe")
+set(CMAKE_ASM_COMPILER "C:/iar/ewarm-9.70.2/arm/bin/iasmarm.exe")
+set(CMAKE_C_COMPILER   "C:/iar/ewarm-9.70.2/arm/bin/iccarm.exe")
+set(CMAKE_CXX_COMPILER "C:/iar/ewarm-9.70.2/arm/bin/iccarm.exe")
 
 # Avoids running the linker during try_compile()
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
@@ -21,6 +21,6 @@ if(CMAKE_GENERATOR MATCHES "^Ninja.*$")
   find_program(CMAKE_MAKE_PROGRAM
     NAMES ninja.exe
     PATHS $ENV{PATH}
-          "C:/iar/ewarm-9.60.4/common/bin"
+          "C:/iar/ewarm-9.70.2/common/bin"
     REQUIRED)
 endif()


### PR DESCRIPTION
This PR updates the reference toolchain in the CMake Tutorial to `cxarm-9.70.2`.