### PR TITLE
examples/trustzone: Clarify TODO for non-secure dependency

### DIFF
--- a/examples/trustzone/CMakeLists.txt
+++ b/examples/trustzone/CMakeLists.txt
@@ -5,6 +5,7 @@ project(TrustZone LANGUAGES C)
 add_subdirectory(secure)
 add_subdirectory(non-secure)
 
-# TODO 1: Add `secure` as a dependency for `non-secure`
+# TODO 1: Add `secure-import-lib` as a dependency for `non-secure`
+add_custom_target()
 add_dependencies()
 


### PR DESCRIPTION
Updated the TODO comment to specify 'secure-import-lib' as a dependency for 'non-secure'.