### PR TITLE
examples: Infer C-SPY parms towards portable tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,17 @@ enable_testing()
 
 - Then use [`add_test()`](https://cmake.org/cmake/help/latest/command/add_test.html) to encapsulate the command line `cspybat` needs. In the example below, the parameters are adjusted for simulating a generic Arm Cortex-M4 target environment:
 ```cmake
+# Infers additional information from CMAKE_C_COMPILER
+cmake_path(GET CMAKE_C_COMPILER PARENT_PATH BIN_DIR)
+cmake_path(GET BIN_DIR PARENT_PATH TOOLKIT_DIR)
+cmake_path(GET TOOLKIT_DIR FILENAME TOOLKIT)
+
 add_test(NAME tutorialTest
-         COMMAND /opt/iar/cxarm/common/bin/CSpyBat
+         COMMAND ${BIN_DIR}/../../common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iar/cxarm/arm/bin/libarmproc.so
-         /opt/iar/cxarm/arm/bin/libarmsim2.so
-         --plugin=/opt/iar/cxarm/arm/bin/libarmLibsupportUniversal.so
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}PROC{CMAKE_SHARED_LIBRARY_SUFFIX}
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}SIM2${CMAKE_SHARED_LIBRARY_SUFFIX}
+         --plugin=${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}LibsupportUniversal${CMAKE_SHARED_LIBRARY_SUFFIX}
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:tutorial>
          # C-SPY driver options

--- a/examples/custom/CMakeLists.txt
+++ b/examples/custom/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 4.1.2)
 
-# TODO 1: Include CMake modules to the project
-
 project(custom)
+
+# TODO 1: Include CMake modules to the project
+list()
+include()
+include()
+
+# Enable IAR Language Extensions
+set(C_EXTENSIONS ON)
 
 # Add multiple executables
 add_executable(sqrt_test)
@@ -26,5 +32,5 @@ set_target_properties(
 )
 
 # Add simulated tests
-iar_cspysim(sqrt_test)
-iar_cspysim(sqrtf_test)
+iar_cspysim(sqrt_test "ticks:")
+iar_cspysim(sqrtf_test "ticks:")

--- a/examples/custom/iar-cspysim.cmake
+++ b/examples/custom/iar-cspysim.cmake
@@ -2,45 +2,47 @@ include_guard()
 
 enable_testing()
 
-# Facilitate adding C-SPY tests driven by CTest
-macro(iar_cspysim TARGET)
-  find_program(CSPYBAT
-    NAMES CSpyBat CSpyBat.exe
-    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
-    PATH_SUFFIXES common/bin
-    REQUIRED
-  )
-  cmake_path(GET CSPYBAT PARENT_PATH COMMON_DIR)
+cmake_path(GET CMAKE_C_COMPILER PARENT_PATH BIN_DIR)
+cmake_path(GET BIN_DIR PARENT_PATH TOOLKIT_DIR)
+cmake_path(GET TOOLKIT_DIR FILENAME TOOLKIT)
 
-  find_library(LIBPROC
-    NAMES libarmproc.so libarmPROC.so armproc.dll
-    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
-    PATH_SUFFIXES arm/bin
+# Facilitate adding C-SPY tests driven by CTest
+macro(iar_cspysim TARGET PASS_REGEX)
+  find_program(cspybat
+    NAMES CSpyBat${CMAKE_HOST_EXECUTABLE_SUFFIX}
+    HINTS ${TOOLKIT_DIR}/../common/bin
     REQUIRED
   )
-  find_library(LIBSIM
-    NAMES libarmsim2.so libarmSIM2.so armsim2.dll
-    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
-    PATH_SUFFIXES arm/bin
+
+  find_library(libproc
+    NAMES ${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}PROC${CMAKE_SHARED_LIBRARY_SUFFIX}
+          ${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}proc${CMAKE_SHARED_LIBRARY_SUFFIX}
+    HINTS ${BIN_DIR}
     REQUIRED
   )
-  find_library(LIBSUPPORT
-    NAMES libarmLibsupportUniversal.so armLibsupportUniversal.dll
-    HINTS /opt/iar/cxarm /opt/iarsystems/bxarm /iar/ewarm-9.70.1
-    PATH_SUFFIXES arm/bin
+  find_library(libsim
+    NAMES ${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}SIM2${CMAKE_SHARED_LIBRARY_SUFFIX}
+          ${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}sim2${CMAKE_SHARED_LIBRARY_SUFFIX}
+    HINTS ${BIN_DIR}
+    REQUIRED
+  )
+  find_library(libsupportuniversal
+    NAMES ${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}LibsupportUniversal${CMAKE_SHARED_LIBRARY_SUFFIX}
+          ${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}libsupportuniversal${CMAKE_SHARED_LIBRARY_SUFFIX}
+    HINTS ${BIN_DIR}
     REQUIRED
   )
 
   add_test(
     NAME ${TARGET}
-    COMMAND ${CSPYBAT} ${LIBPROC} ${LIBSIM}
-      --plugin=${LIBSUPPORT}
+    COMMAND ${cspybat} ${libproc} ${libsim}
+      --plugin=${libsupportuniversal}
       --debug_file=$<TARGET_FILE:${TARGET}>
       --macro=${CMAKE_CURRENT_SOURCE_DIR}/systick.mac
       --silent
       --backend
         --cpu=cortex-m4
         --semihosting )
-  # More than zero ticks are expected for this test
-  set_property(TEST ${TARGET} PROPERTY PASS_REGULAR_EXPRESSION "ticks: ")
+  # Set expected result for passing the test
+  set_property(TEST ${TARGET} PROPERTY PASS_REGULAR_EXPRESSION "${PASS_REGEX}")
 endmacro()

--- a/examples/custom/iar-custom.cmake
+++ b/examples/custom/iar-custom.cmake
@@ -1,9 +1,6 @@
 include_guard()
 
 # Enable all CMake default build configurations
-list(APPEND CMAKE_CONFIGURATION_TYPES Debug)
-list(APPEND CMAKE_CONFIGURATION_TYPES Release)
-list(APPEND CMAKE_CONFIGURATION_TYPES RelWithDebInfo)
 list(APPEND CMAKE_CONFIGURATION_TYPES MinSizeRel)
 
 # Add IAR C/C++ Compiler custom configuration for High Speed

--- a/examples/custom/sqrt.c
+++ b/examples/custom/sqrt.c
@@ -1,6 +1,6 @@
 /**************************************************
  *
- * Copyright (c) 2025 IAR Systems AB.
+ * Copyright (c) 2026 IAR Systems AB.
  *
  * See LICENSE for detailed license information.
  *
@@ -14,8 +14,8 @@
 #define ITERATIONS 100000
 #define INTERRUPT  10000
 
-const float f_input = 2.0f;
-float f_result;
+const double d_input = 2.0;
+double d_result;
 uint32_t ticks = 0;
 
 void SysTick_Handler(void);
@@ -28,7 +28,7 @@ void main()
   __enable_interrupt();
 
   for (uint32_t i = 0; i < ITERATIONS; i++) 
-    f_result = sqrtf(f_input);
+    d_result = sqrt(d_input);
 
   __disable_interrupt();
 

--- a/examples/custom/sqrtf.c
+++ b/examples/custom/sqrtf.c
@@ -1,6 +1,6 @@
 /**************************************************
  *
- * Copyright (c) 2025 IAR Systems AB.
+ * Copyright (c) 2026 IAR Systems AB.
  *
  * See LICENSE for detailed license information.
  *
@@ -14,8 +14,8 @@
 #define ITERATIONS 100000
 #define INTERRUPT  10000
 
-const double d_input = 2.0;
-double d_result;
+const float f_input = 2.0f;
+float f_result;
 uint32_t ticks = 0;
 
 void SysTick_Handler(void);
@@ -28,7 +28,7 @@ void main()
   __enable_interrupt();
 
   for (uint32_t i = 0; i < ITERATIONS; i++) 
-    d_result = sqrt(d_input);
+    f_result = sqrtf(f_input);
 
   __disable_interrupt();
 

--- a/examples/libs/CMakeLists.txt
+++ b/examples/libs/CMakeLists.txt
@@ -12,20 +12,21 @@ add_subdirectory()
 # TODO 5: Link the `lib` against `libs`
 target_link_libraries()
 
-target_compile_options(libs PRIVATE --cpu=cortex-m4)
-
 target_link_options(libs PRIVATE
   --cpu=cortex-m4
   --semihosting)
 
 enable_testing()
 
+cmake_path(GET CMAKE_C_COMPILER PARENT_PATH BIN_DIR)
+cmake_path(GET BIN_DIR PARENT_PATH TOOLKIT_DIR)
+cmake_path(GET TOOLKIT_DIR FILENAME TOOLKIT)
 add_test(NAME libs-test
-         COMMAND /opt/iarsystems/bxarm/common/bin/CSpyBat
+         COMMAND ${BIN_DIR}/../../common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iarsystems/bxarm/arm/bin/libarmPROC.so
-         /opt/iarsystems/bxarm/arm/bin/libarmSIM2.so
-         --plugin=/opt/iarsystems/bxarm/arm/bin/libarmLibsupportUniversal.so
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}PROC${CMAKE_SHARED_LIBRARY_SUFFIX}
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}SIM2${CMAKE_SHARED_LIBRARY_SUFFIX}
+         --plugin=${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}LibsupportUniversal${CMAKE_SHARED_LIBRARY_SUFFIX}
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:libs>
          # C-SPY driver options

--- a/examples/libs/lib/CMakeLists.txt
+++ b/examples/libs/lib/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources()
 # TODO 3: Using the `PUBLIC` scope, expose the `lib` headers (inc) to other targets
 target_include_directories()
 
-target_compile_options(lib PRIVATE --cpu=cortex-m4)
+# Any target linking against the library will inherit its PUBLIC compiler settings
+target_compile_options(lib PUBLIC --cpu=cortex-m4)

--- a/examples/mix/CMakeLists.txt
+++ b/examples/mix/CMakeLists.txt
@@ -16,12 +16,15 @@ target_link_options(mix PRIVATE
 
 enable_testing()
 
+cmake_path(GET CMAKE_C_COMPILER PARENT_PATH BIN_DIR)
+cmake_path(GET BIN_DIR PARENT_PATH TOOLKIT_DIR)
+cmake_path(GET TOOLKIT_DIR FILENAME TOOLKIT)
 add_test(NAME mix-test
-         COMMAND /opt/iarsystems/bxarm/common/bin/CSpyBat
+         COMMAND ${BIN_DIR}/../../common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iarsystems/bxarm/arm/bin/libarmPROC.so
-         /opt/iarsystems/bxarm/arm/bin/libarmSIM2.so
-         --plugin=/opt/iarsystems/bxarm/arm/bin/libarmLibsupportUniversal.so
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}PROC${CMAKE_SHARED_LIBRARY_SUFFIX}
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}SIM2${CMAKE_SHARED_LIBRARY_SUFFIX}
+         --plugin=${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}LibsupportUniversal${CMAKE_SHARED_LIBRARY_SUFFIX}
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:mix>
          # C-SPY driver options

--- a/examples/version/CMakeLists.txt
+++ b/examples/version/CMakeLists.txt
@@ -21,12 +21,15 @@ target_link_options(version PRIVATE
 
 enable_testing()
 
+cmake_path(GET CMAKE_C_COMPILER PARENT_PATH BIN_DIR)
+cmake_path(GET BIN_DIR PARENT_PATH TOOLKIT_DIR)
+cmake_path(GET TOOLKIT_DIR FILENAME TOOLKIT)
 add_test(NAME version-test
-         COMMAND /opt/iarsystems/bxarm/common/bin/CSpyBat
+         COMMAND ${BIN_DIR}/../../common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iarsystems/bxarm/arm/bin/libarmPROC.so
-         /opt/iarsystems/bxarm/arm/bin/libarmSIM2.so
-         --plugin=/opt/iarsystems/bxarm/arm/bin/libarmLibsupportUniversal.so
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}PROC${CMAKE_SHARED_LIBRARY_SUFFIX}
+         ${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}SIM2${CMAKE_SHARED_LIBRARY_SUFFIX}
+         --plugin=${BIN_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${TOOLKIT}LibsupportUniversal${CMAKE_SHARED_LIBRARY_SUFFIX}
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:version>
          # C-SPY driver options


### PR DESCRIPTION
This PR changes the way parameters are passed to CSpyBat, resulting in improved portability.