### PR TITLE
Implement recursion limit in callee function

### DIFF
--- a/examples/cstat/callee.c
+++ b/examples/cstat/callee.c
@@ -3,6 +3,13 @@
 
 void callee(void)
 {
-  caller();
-}
+  static unsigned int g_recursion_level = 0;
+  
+  ++g_recursion_level;
 
+  /* A limit to avoid stack overflow due to infinite recursion */ 
+  if (g_recursion_level < 10)
+    callee();
+  
+  while(1);
+}


### PR DESCRIPTION
Added recursion limit to prevent stack overflow in the `cstat` example.