### PR TITLE
Implement a limiter to the recursive call of callee() in caller()

### DIFF
--- a/examples/cstat/caller.c
+++ b/examples/cstat/caller.c
@@ -3,5 +3,10 @@
 
 void caller(void)
 {
-  callee();
+  static unsigned int g_recursion_level = 0;
+  
+  g_recursion_level++;
+  
+  if (g_recursion_level < 10)
+    callee();
 }


### PR DESCRIPTION
Add a limit of 10 levels for `caller()`, to avoid stack overflow.