### PR TITLE
Fix crc32() proto

### DIFF
--- a/examples/checksum/crc32.c
+++ b/examples/checksum/crc32.c
@@ -2,7 +2,7 @@
 
 #define CRC32_POLY 0x04C11DB7
 
-uint32_t crc32(uint32_t crc, uint32_t const* start_addr, uint32_t const* end_addr)
+uint32_t crc32(uint32_t crc, uint32_t const* start_addr, uint32_t const* checksum_addr)
 {
   const uint32_t crc32NibbleLUT[16] = {
     0x00000000,CRC32_POLY,0x09823B6E,0x0D4326D9,
@@ -10,7 +10,7 @@ uint32_t crc32(uint32_t crc, uint32_t const* start_addr, uint32_t const* end_add
     0x2608EDB8,0x22C9F00F,0x2F8AD6D6,0x2B4BCB61,
     0x350C9B64,0x31CD86D3,0x3C8EA00A,0x384FBDBD, };
 
-  for (const uint32_t* ptr = start_addr; ptr < end_addr; ptr++) {
+  for (const uint32_t* ptr = start_addr; ptr < checksum_addr; ptr++) {
     crc = crc ^ *ptr;
     /* 8 rounds * 4-bit(nibble) = 32 bit(word) */
     crc = (crc << 4) ^ crc32NibbleLUT[crc >> 28];

--- a/examples/checksum/crc32.h
+++ b/examples/checksum/crc32.h
@@ -3,5 +3,5 @@
 typedef unsigned long uint32_t;
 typedef char          uint8_t;
 
-uint32_t crc32(uint32_t crc, uint32_t const* start_addr, uint32_t const* end_addr);
+uint32_t crc32(uint32_t crc, uint32_t const* start_addr, uint32_t const* checksum_addr);
 

--- a/examples/checksum/main.c
+++ b/examples/checksum/main.c
@@ -18,12 +18,13 @@ void main()
   // Print out the checksum calculated by crc32()
   printf(" crc32() checksum: 0x%08X\n", crc);
 
-  // Validate the checksum before
+  // Validate the application integrity at initialization
   if (crc == __checksum)
   {
     printf("    Checksum-test: PASS");
   } else {
     printf("    Checksum-test: FAIL");
+
     // Add countermeasures for integrity failure
   }
 


### PR DESCRIPTION
Disambiguate  `crc32()` parameters.